### PR TITLE
Hai reveal

### DIFF
--- a/data/hai reveal.txt
+++ b/data/hai reveal.txt
@@ -8,7 +8,40 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-mission "Rumskib: Hai Rescue: Ooonem"
+# The "release" way to disable hai slave missions is strangely incomplete - fix so we can replace them in a consistent way
+disable mission
+	"Hai Rescue: Yeertle Hint"
+	"Hai Rescue: Ooonem Hint"
+
+mission "Rumskib: Hai Rescue: Ooonem Hint"
+	landing
+	name "A (Short) Angel of Death"
+	description "There have been some mysterious deaths on <destination>."
+	source
+		near "Alcyone" 3
+		government "Republic" "Syndicate"
+		attributes "spaceport"
+		not attributes "station"
+		not planet "Stormhold"
+	destination Stormhold
+	to offer
+		has "Hai Leaks Response 6: active"
+		has "event: slightly lost"
+		not "Rumskib: Hai Rescue: Ooonem: offered"
+		not "Hai Reveal [B01-A] The Blockade Goes Up: offered"
+		random < 30
+	on offer
+		conversation
+			`As you come in to land at the spaceport, you listen to the usual chatter of captains coming and going. To your surprise, on one of the lower, less obvious bands, you hear a pair of captains talking about the pirate world of <planet>. Apparently these two have enough connections to profit off the occasional trip there, but one of them is warning the other not to go by at the moment.`
+			`	You listen in carefully as the speaker relays that there's some kind of hunt going on there. All the ships are being searched before departure, and there's a lot of paranoid goons with weapons hot. A merchant has been killed on his own ship, while it was parked in the spaceport, and random people keep getting into firefights with a short, hooded, "angel of death" in dark alleyways. So far, no one claims to know what's going on.`
+			`	It's really hard to say what this could be, but it might be worth checking out.`
+				accept
+	to complete
+		has "Rumskib: Hai Rescue: Ooonem: offered"
+	to fail
+		has "Hai Reveal [B01-A] The Blockade Goes Up: offered"
+		
+mission "Rumskib: Hai Rescue: Ooonem: offered"
 	name "Return Ooonem"
 	description "Transport the Hai you rescued to <destination>. Payment is <payment>."
 	source "Stormhold"
@@ -29,7 +62,7 @@ mission "Rumskib: Hai Rescue: Ooonem"
 				has "Ooonem Transmitter"
 			branch nohint
 				and
-					not "Hai Rescue: Ooonem Hint: offered"
+					not "Rumskib: Hai Rescue: Ooonem Hint"
 					not "Hai Rescue: Ooonem (defer count)"
 			`Following reports of the last time the "angel of death" was sighted, you end up loitering in a twisting street parallel to a main thoroughfare. The few people using it hurry by quickly, and rarely seem to travel any great distance down this street. One very surly looking individual gives you a sour glare on his way past, a collection of weapons on full display. He looks a lot like you'd expect a bounty hunter to look, and as he moves out of sight you observe a shadow, previously motionless, detach from a spot on a wall and head back your direction, laser rifle pointed in the direction of the departing individual. As the shadow approaches, you see there's a lot of hair sticking out from their hood. They might be a Hai. Do you want to talk to them?`
 				goto start
@@ -119,6 +152,35 @@ mission "Rumskib: Hai Rescue: Ooonem"
 		fleet "Large Core Pirates" 1
 		fleet "Small Core Pirates" 1
 
+mission "Rumskib: Hai Rescue: Yeertle Hint"
+	landing
+	name "Investigate a Were-Squirrel"
+	description `A truly outlandish rumor has been floating around that there might be a "were-squirrel" (Hai) hiding out on <destination>.`
+	source
+		near "Betelgeuse" 4
+		government "Republic" "Syndicate"
+		attributes "spaceport"
+		not attributes "station"
+		not planet "Prime"
+	destination Prime
+	to offer
+		"combat rating" > 50
+		has "Hai Leaks Response 6: active"
+		has "event: slightly lost"
+		not "Rumskib: Hai Rescue: Yeertle Family: offered"
+		not "event: hai-human treaty signed"
+		random < 50
+	on offer
+		conversation
+			`As you come in to land at the spaceport, you listen to the usual chatter of captains coming and going. Often this contains useful tidbits, such as which merchants are ticked off at the moment and whether you should expect to wait a while for refueling. Today, though, you overhear a captain telling an acquaintance a remarkable tale.`
+			`	Apparently, there is a man-beast on <planet>, and when the other captain laughs at the idea of a modern "werewolf," the first one is quick to clarify that it's more like a meter and a half tall "were-squirrel." There seems to be some confused discussion about the mythology of such beasts being revealed when caught staring at bright lights until a third captain, listening in the same as you, butts in to inform them that one of them stole that from a popular show a few years back.`
+			`	You stop listening on your final approach as the conversation descends into a good-natured argument. Nevertheless, it sounds like a lead on a possible stranded Hai that would be worth following up.`
+				accept
+	to complete
+		has "Rumskib: Hai Rescue: Yeertle Family: offered"
+	to fail
+		has "event: hai-human treaty signed"
+
 
 mission "Rumskib: Hai Rescue: Yeertle Family"
 	name "Return the Yeertle family"
@@ -138,7 +200,7 @@ mission "Rumskib: Hai Rescue: Yeertle Family"
 	on offer
 		conversation
 			branch nohint
-				not "Hai Rescue: Yeertle Hint: offered"
+				not "Rumskib: Hai Rescue: Yeertle Hint"
 			`Wandering around after dark you find yourself down an alley near the spaceport, huddled in an alcove against the drizzle while you keep an eye out for anything suspicious, apparently last rumored to be around here. After a while, a few dozen meters ahead, you see a short man with a strange necklace. As he walks past a power transfer unit, the man shimmers and you see faintly-visible, squirrel-like features. It seems the necklace is a projector of a human hologram concealing a Hai. He is sticking to the shadows, trying to avoid being seen.`
 				goto start
 			label nohint

--- a/data/hai reveal.txt
+++ b/data/hai reveal.txt
@@ -31,6 +31,7 @@ mission "Rumskib: Hai Rescue: Ooonem Hint"
 		not "Hai Reveal [B01-A] The Blockade Goes Up: offered"
 		random < 30
 	on offer
+		set "Hai Rescue: Ooonem Hint: offered"
 		conversation
 			`As you come in to land at the spaceport, you listen to the usual chatter of captains coming and going. To your surprise, on one of the lower, less obvious bands, you hear a pair of captains talking about the pirate world of <planet>. Apparently these two have enough connections to profit off the occasional trip there, but one of them is warning the other not to go by at the moment.`
 			`	You listen in carefully as the speaker relays that there's some kind of hunt going on there. All the ships are being searched before departure, and there's a lot of paranoid goons with weapons hot. A merchant has been killed on his own ship, while it was parked in the spaceport, and random people keep getting into firefights with a short, hooded, "angel of death" in dark alleyways. So far, no one claims to know what's going on.`

--- a/data/hai reveal.txt
+++ b/data/hai reveal.txt
@@ -28,6 +28,7 @@ mission "Rumskib: Hai Rescue: Ooonem Hint"
 		has "Hai Leaks Response 6: active"
 		has "event: slightly lost"
 		not "Rumskib: Hai Rescue: Ooonem: offered"
+		not "Hai Rescue: Ooonem: offered"
 		not "Hai Reveal [B01-A] The Blockade Goes Up: offered"
 		random < 30
 	on offer
@@ -38,7 +39,9 @@ mission "Rumskib: Hai Rescue: Ooonem Hint"
 			`	It's really hard to say what this could be, but it might be worth checking out.`
 				accept
 	to complete
-		has "Rumskib: Hai Rescue: Ooonem: offered"
+		or
+			has "Rumskib: Hai Rescue: Ooonem: offered"
+			has "Hai Rescue: Ooonem: offered"
 	to fail
 		has "Hai Reveal [B01-A] The Blockade Goes Up: offered"
 	on fail
@@ -65,7 +68,7 @@ mission "Rumskib: Hai Rescue: Ooonem"
 				has "Ooonem Transmitter"
 			branch nohint
 				and
-					not "Rumskib: Hai Rescue: Ooonem Hint"
+					not "Hai Rescue: Ooonem Hint: offered"
 					not "Hai Rescue: Ooonem (defer count)"
 			`Following reports of the last time the "angel of death" was sighted, you end up loitering in a twisting street parallel to a main thoroughfare. The few people using it hurry by quickly, and rarely seem to travel any great distance down this street. One very surly looking individual gives you a sour glare on his way past, a collection of weapons on full display. He looks a lot like you'd expect a bounty hunter to look, and as he moves out of sight you observe a shadow, previously motionless, detach from a spot on a wall and head back your direction, laser rifle pointed in the direction of the departing individual. As the shadow approaches, you see there's a lot of hair sticking out from their hood. They might be a Hai. Do you want to talk to them?`
 				goto start
@@ -171,9 +174,11 @@ mission "Rumskib: Hai Rescue: Yeertle Hint"
 		has "Hai Leaks Response 6: active"
 		has "event: slightly lost"
 		not "Rumskib: Hai Rescue: Yeertle Family: offered"
+		not "Hai Rescue: Yeertle Family: offered"
 		not "event: hai-human treaty signed"
 		random < 50
 	on offer
+		set "Hai Rescue: Yeertle Hint: offered"
 		conversation
 			`As you come in to land at the spaceport, you listen to the usual chatter of captains coming and going. Often this contains useful tidbits, such as which merchants are ticked off at the moment and whether you should expect to wait a while for refueling. Today, though, you overhear a captain telling an acquaintance a remarkable tale.`
 			`	Apparently, there is a man-beast on <planet>, and when the other captain laughs at the idea of a modern "werewolf," the first one is quick to clarify that it's more like a meter and a half tall "were-squirrel." There seems to be some confused discussion about the mythology of such beasts being revealed when caught staring at bright lights until a third captain, listening in the same as you, butts in to inform them that one of them stole that from a popular show a few years back.`
@@ -183,6 +188,8 @@ mission "Rumskib: Hai Rescue: Yeertle Hint"
 		has "Rumskib: Hai Rescue: Yeertle Family: offered"
 	to fail
 		has "event: hai-human treaty signed"
+	on fail
+		set "Hai Rescue: Yeertle Hint: offered"
 
 
 mission "Rumskib: Hai Rescue: Yeertle Family"
@@ -203,7 +210,7 @@ mission "Rumskib: Hai Rescue: Yeertle Family"
 	on offer
 		conversation
 			branch nohint
-				not "Rumskib: Hai Rescue: Yeertle Hint"
+				not "Hai Rescue: Yeertle Hint: offered"
 			`Wandering around after dark you find yourself down an alley near the spaceport, huddled in an alcove against the drizzle while you keep an eye out for anything suspicious, apparently last rumored to be around here. After a while, a few dozen meters ahead, you see a short man with a strange necklace. As he walks past a power transfer unit, the man shimmers and you see faintly-visible, squirrel-like features. It seems the necklace is a projector of a human hologram concealing a Hai. He is sticking to the shadows, trying to avoid being seen.`
 				goto start
 			label nohint
@@ -289,7 +296,7 @@ mission "Rumskib: Hai Rescue: Yeertle Family"
 		fleet "Small Core Pirates" 1
 
 
-mission "Hai Leaks Response 1"
+mission "Rumskib: Hai Leaks Response 1"
 	landing
 	name "Hai message to <planet>"
 	description "Take the diplomatic ID from the box from Sayari to <planet>."
@@ -299,7 +306,7 @@ mission "Hai Leaks Response 1"
 		has "event: hr: exploration period"
 	on offer
 		log "People" "Sayari" `Ambassador Sayari, a Hai, served as their envoy to the human government a century ago (although no public records of this exist in human space). Her experience has placed her in charge of coordinating the Hai response to the crisis of their continued secrecy.`
-		
+		set "Hai Leaks Response 1: offered"
 		conversation
 			`As you arrive on Hai-home, you find that a reasonable security detachment is waiting at your designated landing berth.`
 			branch rudeawakening
@@ -352,9 +359,11 @@ mission "Hai Leaks Response 1"
 			`	"Oh," she says, "we've treated the Syndicate as a de facto government for many decades now; with the amount of influence they have it was the only prudent thing to do."`
 			`	You take the boxed item with you, and an escort awaits to return you to your ship. As the door behind you closes, you hear Sayari mutter to someone, "It really was much easier when they just had one government though. What a mess."`
 				accept
+	on complete
+		set "Hai Leaks Response 1: done"
 
 
-mission "Hai Leaks Response 2"
+mission "Rumskib: Hai Leaks Response 2"
 	landing
 	name "Collect Representatives"
 	description "Collect human government representatives from <stopovers> and take them to <destination>."
@@ -370,6 +379,7 @@ mission "Hai Leaks Response 2"
 	on offer
 		event "pirates respond to leaks"
 		log "People" "Xilin Yang" `Deputy Minister Yang works in the Foreign Affairs department of the Republic government. He is a pleasant and astute man. Handling the Hai secrecy crisis has become his job while the majority of the foreign ministry remains engaged with the fallout from the Free Worlds and recent peace.`
+		set "Hai Leaks Response 2: offered"
 		conversation
 			`On approach to the spaceport on Earth, you request to speak to an official of significant standing on diplomatic business. Thanks to your renown from the Pug war, you are able to shortcut objections stemming from you yourself not being a diplomat. The diplomatic ID from the box Sayari gave you, when presented, also seems to trigger some sort of classified override, fast-tracking the process from the quoted "two to three business days" to "two hours after landing."`
 			`	The Republic's Deputy Minister for Foreign Affairs meets you in a private room at the spaceport.`
@@ -405,13 +415,14 @@ mission "Hai Leaks Response 2"
 		dialog phrase "generic stopover on visit"
 	on complete
 		log `Brought human diplomatic representatives from each human faction to Hai-home to address the crisis. Something drastic needs to be done to keep the secret from entirely bursting, but they know how long they will have to work with. Asked to rout pirates hoping to benefit from the chaos while they work on a solution.`
+		set "Hai Leaks Response 2: done"
 
 mission "Hai Leaks Response 2A"
 	landing
 	invisible
 	source Deep
 	to offer
-		has "Hai Leaks Response 2: active"
+		has "Rumskib: Hai Leaks Response 2: active"
 	on offer
 		log "People" "Alondo Gruyere" `Alondo is working to develop the diplomatic corps for the Free Worlds. Due to a lack of serious appointed positions (with the few already existing occupied as ambassadors to the Republic), he is looking after the Free Worlds' interests as a diplomat to the Hai.`
 		conversation
@@ -425,24 +436,24 @@ mission "Hai Leaks Response 2A"
 			`	Fortunately, after an hour and a couple of drinks, the embarrassment is long-forgotten when you return to your ship.`
 				decline
 	
-mission "Hai Leaks Response 2B"
+mission "Rumskib: Hai Leaks Response 2B"
 	landing
 	source
 		government "Republic" "Syndicate" "Free Worlds"
 		not planet "Deep" "Foundry" "Watcher"
 	to offer
-		has "Hai Leaks Response 2: active"
+		has "Rumskib: Hai Leaks Response 2: active"
 	on offer
 		conversation
 			`While refueling on <origin>, you see that the media circus is continuing unabated. Apparently, pirates are renewing attacks on trade lanes in the north, utilizing some of the strange weapons observed in the recorded clip of Hai ships fighting each other. Goodness knows how they got their hands on them, but it can't be good news.`
 				decline
 
-mission "Hai Leaks Response 2C"
+mission "Rumskib: Hai Leaks Response 2C"
 	landing
 	invisible
 	source Foundry
 	to offer
-		has "Hai Leaks Response 2: active"
+		has "Rumskib: Hai Leaks Response 2: active"
 	on offer
 		log "People" "Terry Adrianopoulos" `Terry Adrianopoulos is the secretary of Samuel Remington, or at least that's how he puts it. Remington mentioned an internal political situation within the Syndicate while glancing at Terry, so there may be something larger at play with her presence. Hopefully it doesn't conflict with resolving the situation with the Hai.`
 		conversation

--- a/data/hai reveal.txt
+++ b/data/hai reveal.txt
@@ -417,7 +417,7 @@ mission "Rumskib: Hai Leaks Response 2"
 		log `Brought human diplomatic representatives from each human faction to Hai-home to address the crisis. Something drastic needs to be done to keep the secret from entirely bursting, but they know how long they will have to work with. Asked to rout pirates hoping to benefit from the chaos while they work on a solution.`
 		set "Hai Leaks Response 2: done"
 
-mission "Hai Leaks Response 2A"
+mission "Rumskib: Hai Leaks Response 2A"
 	landing
 	invisible
 	source Deep

--- a/data/hai reveal.txt
+++ b/data/hai reveal.txt
@@ -284,3 +284,179 @@ mission "Rumskib: Hai Rescue: Yeertle Family"
 		government "Bounty Hunter that Won't Enter Hai Space"
 		personality plunders disables unconstrained
 		fleet "Small Core Pirates" 1
+
+
+mission "Hai Leaks Response 1"
+	landing
+	name "Hai message to <planet>"
+	description "Take the diplomatic ID from the box from Sayari to <planet>."
+	source "Hai-home"
+	destination "Earth"
+	to offer
+		has "event: hr: exploration period"
+	on offer
+		log "People" "Sayari" `Ambassador Sayari, a Hai, served as their envoy to the human government a century ago (although no public records of this exist in human space). Her experience has placed her in charge of coordinating the Hai response to the crisis of their continued secrecy.`
+		
+		conversation
+			`As you arrive on Hai-home, you find that a reasonable security detachment is waiting at your designated landing berth.`
+			branch rudeawakening
+				has "didn't know about hai"
+			action
+				log `Human worlds seem poised to become aware of the Hai's existence. The Hai would like to avoid this. Agreed to assist by representing their interests where travel to human space is required. Their desire was for a human, yet somewhat neutral, party.`
+			`	The Hai aren't usually ones to be concerned about such things, but you suspect that, as an apparent "war hero", they may be more for your own safety than the Hai's.`
+			`	Word of your status in human space also seems to have spread ahead of you, especially considering your apparent reputation on many Hai worlds as one of the few significant human visitors. A small crowd of Hai gather to peek at you on the short walk from the spaceport to the government building you are led to.`
+				goto resume
+			label rudeawakening
+			action
+				log `The Hai are very real, and human worlds seem poised to become aware of their existence. The Hai would like to avoid this. Agreed to assist by representing their interests where travel to human space is required. Their desire was for a human, yet somewhat neutral, party.`
+			`	You haven't really seen very much of the Hai so far, and you can't help but think the size of the detachment is rather militant of them. It's impossible to judge if it's for your safety or whether, given your status as a "war hero", it's for theirs.`
+			`	Word of your status in human space also seems to have spread ahead of you, perhaps because you are a significant human visitor in the current climate. A moderate crowd of Hai gather to peek at you on the short walk from the spaceport to the government building you are led to.`
+			label resume
+			`	Several of the Hai guarding you usher you off to the left to avoid a gathering crowd.`
+			choice
+				`	(Follow their directions silently.)`
+					goto observe
+				`	"Why do I have such a large security detachment?"`
+			`	The Hai closest to you, who happens to have a very decorated uniform, turns to respond. "It's for crowd control. You've become the center of attention of politicians in a media circus."`
+			`	He looks back to the crowd for a moment. "Life in Hai space is complicated of late, and we want to make sure you are not stopped by crowds with endless questions before reaching your meeting. It would be... inefficient."`
+			choice
+				`	(Keep silent and observe.)`
+				`	"Thank you for your service."`
+					goto thank
+			label observe
+			branch karma
+				karma > 1
+			`	As you are making the walk you hear questions posed and rumors stated. Occasionally you hear words like "survivor" and "dangerous" thrown in amongst the babble.`
+				goto main
+			label karma
+			`	As you are making the walk you hear questions posed and rumors stated. Occasionally you hear words like "honorable" and "reasonable" thrown in amongst the babble.`
+				goto main
+			label thank
+			`	He nods to you, and returns to his duties: holding back one oncoming Hai journalist after another.`
+			label main
+			`	You arrive at a very comfortable office and are received by a mature-looking Hai with the appropriate regalia of a diplomat. She holds out a paw to greet you and says, "My name is Sayari. I was the envoy to the human government a century ago."`
+			`	The present media storm is all the evidence needed to make it clear that the Republic has never mentioned the Hai, nor publicly acknowledged receiving an envoy from them. If they're in on the secret, then they're probably still trying to work out a suppression strategy and have been too busy to send an envoy quicker than your own trip took.`
+			`	Sayari continues, "Our reports tell us that you are a well-known and respected individual in human space. We also know 'Hai' is quickly becoming a buzzword in your space. A few traders brought the news ahead of you."`
+			`	She pauses and looks at you seriously. "We think it would be prudent for you to represent your people as our point of contact. Would you accept such a role?"`
+			`	You give it a moment of thought.`
+			choice
+				`	"That seems practical."`
+				`	"I don't really have an option to refuse, do I?"`
+			`	"Fantastic, you understand the situation," she says, though her tone is much more businesslike than the wording would imply. "In that case, if you could please take this to Earth and communicate with your various governments, then we can begin a liaison on how best to deal with this current scenario."`
+			`	She hands you an officially branded box containing a metallic badge. There is a symbol minutely engraved into the front that you remember seeing on your way into the complex, and must be the Hai government's emblem. Surrounding it in a circle is some sort of pattern, which reminds you of the codes found on identification cards and licenses in human space. On the other side, there is extensive writing in a script that looks to be Hai. From this, you presume that the badge is some sort of diplomatic ID.`
+			choice
+				`	"Various? We only have two governments."`
+			`	"Oh," she says, "we've treated the Syndicate as a de facto government for many decades now; with the amount of influence they have it was the only prudent thing to do."`
+			`	You take the boxed item with you, and an escort awaits to return you to your ship. As the door behind you closes, you hear Sayari mutter to someone, "It really was much easier when they just had one government though. What a mess."`
+				accept
+
+
+mission "Hai Leaks Response 2"
+	landing
+	name "Collect Representatives"
+	description "Collect human government representatives from <stopovers> and take them to <destination>."
+	source "Earth"
+	stopover "Deep"
+	stopover "Foundry"
+	destination "Hai-home"
+	blocked "You have a mission here for the Hai, but you need four bunks free."
+	clearance
+	to offer
+		has "Hai Leaks Response 1: done"
+	passengers 4
+	on offer
+		event "pirates respond to leaks"
+		log "People" "Xilin Yang" `Deputy Minister Yang works in the Foreign Affairs department of the Republic government. He is a pleasant and astute man. Handling the Hai secrecy crisis has become his job while the majority of the foreign ministry remains engaged with the fallout from the Free Worlds and recent peace.`
+		conversation
+			`On approach to the spaceport on Earth, you request to speak to an official of significant standing on diplomatic business. Thanks to your renown from the Pug war, you are able to shortcut objections stemming from you yourself not being a diplomat. The diplomatic ID from the box Sayari gave you, when presented, also seems to trigger some sort of classified override, fast-tracking the process from the quoted "two to three business days" to "two hours after landing."`
+			`	The Republic's Deputy Minister for Foreign Affairs meets you in a private room at the spaceport.`
+			`	"Captain <last>," he steps around the table to grasp your hand in a firm handshake. "Xilin Yang. It's an honor to meet a hero of the Pug crisis such as yourself."`
+			choice
+				`	"It was hard-fought, but it was necessary."`
+				`	"Thanks, but it wasn't as dramatic as they made it out to be. I'm just happy to have helped where I could."`
+					goto humble
+			`	You play the part and try to act noble. Mr. Yang seems more than happy to embody respect for the hero of his preferred narrative.`
+			`	"You're every inch what I expected," he assures you before moving to take his seat.`
+				goto sit
+			label humble
+			`	You shrug, palms up, and explain, "You should listen to the xenoanthropologists. The Pug were just here to test us, to make us really consider what mattered and come together."`
+			`	For a moment his expression falters, and then he seems almost relieved. "You may be a better person than I expected to meet."`
+			`	He offers you a genuine smile as he takes his seat.`
+			label sit
+			`	You sit down opposite him and explain how the Hai have proposed that you be their official contact point for humanity on account of your fame from the war.`
+			`	He asks a few questions for clarity, and when you're done he requests you wait while he makes a call. He leaves the room for a long while, and at one point an aide comes in and offers you refreshments while deliberations continue elsewhere. Much to your surprise the fruity beverage is actually quite light and not too sweet, reminding you briefly that most of humanity's food styles originated here.`
+			`	Eventually Mr. Yang returns. "So sorry for that. I hope you were looked after suitably while you waited."`
+			`	Once you nod your assent, he continues, "Well, obviously the Republic knows about the Hai, but for the moment our official "line" is that the government does not trade in rumors. However, an appropriate response is clearly needed. Republic Intelligence briefed the Cabinet of the Free Worlds Senate just yesterday. They have demanded that they have a diplomatic representative along for any decisions. This is already standard practice for the Syndicate. If you are willing, I will come with you to meet two individuals known as Katya Reynolds and Samuel Remington on Deep and Foundry respectively. I believe you already know them?"`
+			choice
+				`	"Yes."`
+				`	"Samuel Remington?"`
+					goto sam
+			`	"Excellent," he says as he begins to gather stacks of papers, shoving them into a briefcase.`
+				goto end
+			label sam
+			`	"Remington is the Syndicate's head of public relations, and exactly the man we need in an event like this," he explains while gathering two datapads and a selection of folders, shoving them into a briefcase.`
+			label end
+			`	"Now, the situation is progressing quickly and plans are still being made, so I am not entirely sure if it is they themselves who will be coming with us. Someone of Remington's caliber is likely too busy to come personally, but we'll find out when we get there. In any case I think we should go to Deep first for speed, but you are the captain. Shall we be off?"`
+				accept
+	on visit
+		dialog phrase "generic stopover on visit"
+	on complete
+		log `Brought human diplomatic representatives from each human faction to Hai-home to address the crisis. Something drastic needs to be done to keep the secret from entirely bursting, but they know how long they will have to work with. Asked to rout pirates hoping to benefit from the chaos while they work on a solution.`
+
+mission "Hai Leaks Response 2A"
+	landing
+	invisible
+	source Deep
+	to offer
+		has "Hai Leaks Response 2: active"
+	on offer
+		log "People" "Alondo Gruyere" `Alondo is working to develop the diplomatic corps for the Free Worlds. Due to a lack of serious appointed positions (with the few already existing occupied as ambassadors to the Republic), he is looking after the Free Worlds' interests as a diplomat to the Hai.`
+		conversation
+			`When you land on Deep, Katya is there waiting for you along with Alondo. "<first>! It's so good to see you again! When the Republic briefed the new Chancellor and his Cabinet on the Hai, he brought us in for advice. We thought to try and reach you, but of course you would somehow manage to be in the thick of it before we even knew what was going on."`
+			`	You hug them both in turn and return the greeting. "I thought it seemed odd when they said I was meeting you for this, Katya, but it makes much more sense if you were just easier to get a hold of than Alondo here."`
+			`	"Oh, it was always going to be Alondo," she says, "but there's never a bad excuse for traveling with an old friend, especially when you're meeting other friends too."`
+			`	"Do we have time for a drink before we leave?" asks Alondo.`
+			`	You look around at the busy spaceport and see the workers haven't even noticed your ship waiting for refueling yet.`
+			`	"I think we can spare a short while, and you really should meet Mr. Yang."`
+			`	Mr. Yang had been studiously pretending he wasn't eavesdropping from a distance of a few meters but, before you could call him over, Alondo's slightly suggestive comment of, "Oh, I should definitely meet Mr. Yang," had evidently been overheard.`
+			`	Fortunately, after an hour and a couple of drinks, the embarrassment is long-forgotten when you return to your ship.`
+				decline
+	
+mission "Hai Leaks Response 2B"
+	landing
+	source
+		government "Republic" "Syndicate" "Free Worlds"
+		not planet "Deep" "Foundry" "Watcher"
+	to offer
+		has "Hai Leaks Response 2: active"
+	on offer
+		conversation
+			`While refueling on <origin>, you see that the media circus is continuing unabated. Apparently, pirates are renewing attacks on trade lanes in the north, utilizing some of the strange weapons observed in the recorded clip of Hai ships fighting each other. Goodness knows how they got their hands on them, but it can't be good news.`
+				decline
+
+mission "Hai Leaks Response 2C"
+	landing
+	invisible
+	source Foundry
+	to offer
+		has "Hai Leaks Response 2: active"
+	on offer
+		log "People" "Terry Adrianopoulos" `Terry Adrianopoulos is the secretary of Samuel Remington, or at least that's how he puts it. Remington mentioned an internal political situation within the Syndicate while glancing at Terry, so there may be something larger at play with her presence. Hopefully it doesn't conflict with resolving the situation with the Hai.`
+		conversation
+			`Approaching Foundry, you are hailed and directed to a private hangar where you are greeted personally by Samuel Remington. His appearance is rather casual compared to what you would expect, wearing khakis and a collared tee as opposed to the typical suit and tie business attire that you see on Syndicate businessmen. It is certainly in contrast to a young woman standing behind him, who is wearing the usual business attire in this region.`
+			branch met
+				has "met remington"
+			action
+				log "People" "Samuel Remington" `Samuel Remington is the Syndicate's head of public relations. He is acting as the Syndicate's representative in helping to deal with the situation regarding the Hai.`
+			`	"Captain <last>, is it? I don't believe we've met before," he says while shaking your hand, perhaps a little too firmly. "I'm Samuel Remington, head of the Syndicate's PR department. You may have not heard of me before, but I'm sure you've heard of my work. I..." He stops himself. "You know what, nevermind. We're not here to make small talk. We have bigger things to worry about. I'm looking forward to working alongside you to handle this emerging crisis.`
+			`	"Now, allow me to introduce you to Terry," Remington says while gesturing to the woman behind him.`
+				goto next
+			label met
+			action
+				log "People" "Samuel Remington" `Remington is being sent as the representative of the Syndicate to help deal with the situation regarding the Hai.`
+			`	"Captain <last>, is it? It's been a good while since we last met," he says while shaking your hand, perhaps a little too firmly. He gestures to the woman behind him and says, "Let me introduce you to Terry."`
+			label next
+			`	"Terry Adrianopoulos. Pleasure to meet you," she says with a broad smile and a slight bow. The young woman goes from calculating to gregarious in the blink of an eye as your attention shifts to her. She seems at once pleasant and approachable while at the same time being slightly off-putting and uncanny. It's an eerie feeling.`
+			`	"Terry will be accompanying me as... well, let's call her my secretary," Remington says with a sly smile. Terry seems none too pleased to hear that, but she doesn't correct him. "I have men who can hold the fort here while I'm gone, and I really do need to get some fresh air, so the two of us will be joining you. There is an internal political situation going on within the Syndicate that has been causing me quite the headache recently." His eyes momentarily flick to Terry as he says that, but Remington presses on immediately. "It's nothing I can discuss in detail, with all the NDAs involved, you know, but something I'll certainly enjoy taking a break from.`
+			`	"Now, let's be on our way," he says. "The Hai won't save themselves with us standing here."`
+				decline

--- a/data/hai reveal.txt
+++ b/data/hai reveal.txt
@@ -40,6 +40,8 @@ mission "Rumskib: Hai Rescue: Ooonem Hint"
 		has "Rumskib: Hai Rescue: Ooonem: offered"
 	to fail
 		has "Hai Reveal [B01-A] The Blockade Goes Up: offered"
+	on fail
+		set "Hai Rescue: Ooonem Hint: failed"
 		
 mission "Rumskib: Hai Rescue: Ooonem: offered"
 	name "Return Ooonem"

--- a/data/hai reveal.txt
+++ b/data/hai reveal.txt
@@ -44,7 +44,7 @@ mission "Rumskib: Hai Rescue: Ooonem Hint"
 	on fail
 		set "Hai Rescue: Ooonem Hint: failed"
 		
-mission "Rumskib: Hai Rescue: Ooonem: offered"
+mission "Rumskib: Hai Rescue: Ooonem"
 	name "Return Ooonem"
 	description "Transport the Hai you rescued to <destination>. Payment is <payment>."
 	source "Stormhold"


### PR DESCRIPTION
Rumskibs hai reveal fix is incomplete, dont know how it went un noticed for so long

the main game file has removed hai response 1 and 2, back in, 0.10.1, one of the offer conditions for hai response 3 is "Hai Leaks Response 2: done", which is impossible to attain


also, in rescue missions, the hint and actual mission are kinda inter dependent, so id suggest adding both